### PR TITLE
TabBar 사용한 화면 전환 구현.

### DIFF
--- a/lib/CustomNavigator.dart
+++ b/lib/CustomNavigator.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class CustomNavigator extends StatefulWidget {
+  final Widget page;
+  final Key navigatorKey;
+  const CustomNavigator({Key? key, required this.page, required this.navigatorKey}) : super(key: key);
+
+  @override
+  _CustomNavigatorState createState() => _CustomNavigatorState();
+}
+
+class _CustomNavigatorState extends State<CustomNavigator> with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return Navigator(
+      key: widget.navigatorKey,
+      onGenerateRoute: (_) => MaterialPageRoute(builder: (context) => widget.page),
+    );
+  }
+}

--- a/lib/MyHome.dart
+++ b/lib/MyHome.dart
@@ -1,7 +1,14 @@
 import 'package:flutter/material.dart';
 import 'MyAppBar.dart';
 
-class MyHome extends StatelessWidget {
+class MyHome extends StatefulWidget {
+  const MyHome({super.key});
+
+  @override
+  State<MyHome> createState() => _MyHomeState();
+}
+class _MyHomeState extends State<MyHome> {
+
   @override
   Widget build(BuildContext context) {
     return const Scaffold(

--- a/lib/MyTabBar.dart
+++ b/lib/MyTabBar.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class MyTabBar extends StatelessWidget {
+  const MyTabBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.transparent,
+      child: const TabBar(
+        tabs: <Tab>[
+          Tab(
+            icon: Icon(Icons.home, size: 30),
+            //text: "홈 화면"
+          ),
+          Tab(
+            icon: Icon(Icons.search, size: 30),
+            //text: "검색"
+          ),
+          Tab(
+            icon: Icon(Icons.analytics, size: 30),
+            //text: "통계"
+          ),
+          Tab(
+            icon: Icon(Icons.settings, size: 30),
+            //text: "설정"
+          )
+        ],
+        labelColor: Colors.blue,
+        unselectedLabelColor: Color.fromRGBO(20, 20, 20, 0.3),
+        isScrollable: false,
+        indicatorColor: Colors.transparent,
+        tabAlignment: TabAlignment.fill,
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:book_juk/MyHome.dart';
 import 'package:flutter/material.dart';
 import 'Search.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'CustomNavigator.dart';
+import 'MyTabBar.dart';
 
 void main() {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
@@ -50,65 +52,51 @@ class Landing extends StatefulWidget {
   const Landing({super.key});
 
   @override
-  State<Landing> createState() => _MyLanding();
+  State<Landing> createState() => _LandingState();
 }
 
-class _MyLanding extends State<Landing> {
-  int _selectedIndex = 0;
+class _LandingState extends State<Landing> {
+  PageController pageController = PageController();
+
+  final List<Widget> _pages = [
+    MyHome(),
+    Search(),
+    Text(
+      "Analytics!!!!!!!!!!!!!!",
+      style: TextStyle(
+        fontSize: 100
+      ),
+      textAlign: TextAlign.center,
+    ),
+    Text(
+      "SEEEEEEEEEETTTTTTTTTTTTTTTTTINGSSSSSSSSS!!!!!!!",
+      style: TextStyle(
+        fontSize: 100
+      ),
+      textAlign: TextAlign.center,
+    )
+  ];
+  final _navigatorKeyList = List.generate(4, (index) => GlobalKey<NavigatorState>());
 
   @override
   Widget build(BuildContext context) {
-    void _onItemTapped(int index) {
-      setState(() {
-        _selectedIndex = index;
-      });
-    }
-
-    List<Widget> navItems = [
-      MyHome(),
-      Search(),
-      Text(
-        "Analytics!!!!!!!!!!!!!!",
-        style: TextStyle(
-          fontSize: 100
+    return DefaultTabController(
+      length: _pages.length,
+      animationDuration: Duration.zero,
+      child: Scaffold(
+        body: TabBarView(
+          physics: NeverScrollableScrollPhysics(),
+          children: _pages.map(
+            (page) {
+              int index = _pages.indexOf(page);
+              return CustomNavigator(
+                page: page,
+                navigatorKey: _navigatorKeyList[index]
+              );
+            },
+          ).toList()
         ),
-        textAlign: TextAlign.center,
-      ),
-      Text(
-        "SEEEEEEEEEETTTTTTTTTTTTTTTTTINGSSSSSSSSS!!!!!!!",
-        style: TextStyle(
-          fontSize: 100
-        ),
-        textAlign: TextAlign.center,
-      )
-    ];
-
-    return Scaffold(
-      body: navItems[_selectedIndex],
-      bottomNavigationBar: BottomNavigationBar(
-        items: <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: Icon(Icons.home),
-            label: "홈 화면"
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.search),
-            label: "검색"
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.analytics),
-            label: "통계"
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.settings),
-            label: "설정"
-          )
-        ],
-        currentIndex: _selectedIndex,
-        selectedItemColor: Colors.blueAccent,
-        unselectedItemColor: Colors.grey,
-        type: BottomNavigationBarType.fixed,
-        onTap: _onItemTapped
+        bottomNavigationBar: MyTabBar(),
       ),
     );
   }

--- a/lib/search.dart
+++ b/lib/search.dart
@@ -12,7 +12,7 @@ class Search extends StatefulWidget {
   State<Search> createState() => SearchState();
 }
 
-class SearchState extends State<Search> {
+class SearchState extends State<Search>{
   String input = '';
   final int booksPerPage = 10;
   final String ttb = 'ttbsdyhappy2211001';


### PR DESCRIPTION
### **기존 사용한 BottomNavigationBar 방식이 아닌, TabBar를 사용한 화면 전환으로 변경.**

사유 : BottomNavigationBar를 사용하면 화면이 rebuild되기 때문에 사용에 불편함이 있음.
<img src="https://github.com/2023-2-CAU-AI-MP-TeamProject/book_juk/assets/115198461/ae6e5b8e-ca36-4529-ace4-48ad20a153d5" height="400" width = "200">

### **main.dart**
build를 다음과 같이 변경.
```dart
Widget build(BuildContext context) {
    return DefaultTabController(
      length: _pages.length,
      animationDuration: Duration.zero,
      child: Scaffold(
        body: TabBarView(
          physics: NeverScrollableScrollPhysics(),
          children: _pages.map(
            (page) {
              int index = _pages.indexOf(page);
              return CustomNavigator(
                page: page,
                navigatorKey: _navigatorKeyList[index]
              );
            },
          ).toList()
        ),
        bottomNavigationBar: MyTabBar(),
      ),
    );
  }
``` 

### **MyTabBar.dart**
파일 생성. 
길어진 코드로 인해 따로 분리.
TabBar는 Container로 감싸서 color를 지정해야 함.
기본적으로 TabBar는 전환 애니메이션 및 버튼 이외의 스와이프 동작으로도 화면 전환 가능.
해당 코드에서는 이러한 기능들 모두 비활성화.

애니메이션 비활성화 : main.dart의 DefaultTabController의 attribute 중,
```dart
animationDuration: Duration.zero,
``` 
부분으로 제어.

스와이프 비활성화: main.dart의 TabBarView의 attribute 중,
```dart
physics: NeverScrollableScrollPhysics(),
``` 
부분으로 제어.

### **CustomNavigator.dart**
파일 생성.
Navigator를 이용해 이동하나, push, pop 등을 할 것이 아니므로 CustomNavigator 생성.
AutomaticKeepAliveClientMixin 속성을 부여하여 탭이 전환되더라도 이전 화면이 유지되도록 설정.

### **Results**
<img src="https://github.com/2023-2-CAU-AI-MP-TeamProject/book_juk/assets/115198461/b879733a-dac2-49bd-9cc6-fbc21a8e283f" width="200" height="400">
